### PR TITLE
在沒有勾選框的界面，點擊直接顯示人物資料，同時取消長按事件

### DIFF
--- a/UIMain/TabList/PersonList.gd
+++ b/UIMain/TabList/PersonList.gd
@@ -179,8 +179,9 @@ func _populate_basic_data(person_list: Array, action):
 		_sorting_order.ASC:
 			_sorted_list = _sorting_list(person_list.duplicate())
 	for person in _sorted_list:
-		var checkbox = _checkbox(person.id)
+		var checkbox = null
 		if action != Action.LIST:
+			checkbox = _checkbox(person.id)
 			item_list.add_child(checkbox)
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_name(), self, person, checkbox))
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_location().get_name(), self, person, checkbox))
@@ -220,8 +221,9 @@ func _populate_ability_data(person_list: Array, action):
 		_sorting_order.ASC:
 			_sorted_list = _sorting_list(person_list.duplicate())
 	for person in _sorted_list:
-		var checkbox = _checkbox(person.id)
+		var checkbox = null
 		if action != Action.LIST:
+			checkbox = _checkbox(person.id)
 			item_list.add_child(checkbox)
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_name(), self, person, checkbox))
 		item_list.add_child(_clickable_label_with_long_pressed_event(str(person.get_command()), self, person, checkbox))
@@ -256,8 +258,9 @@ func _populate_internal_data(person_list: Array, action):
 		_sorting_order.ASC:
 			_sorted_list = _sorting_list(person_list.duplicate())
 	for person in _sorted_list:
-		var checkbox = _checkbox(person.id)
+		var checkbox = null
 		if action != Action.LIST:
+			checkbox = _checkbox(person.id)
 			item_list.add_child(checkbox)
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_name(), self, person, checkbox))
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_working_task_str(), self, person, checkbox))
@@ -288,8 +291,9 @@ func _populate_military_data(person_list: Array, action):
 		_sorting_order.ASC:
 			_sorted_list = _sorting_list(person_list.duplicate())
 	for person in _sorted_list:
-		var checkbox = _checkbox(person.id)
+		var checkbox = null
 		if action != Action.LIST:
+			checkbox = _checkbox(person.id)
 			item_list.add_child(checkbox)
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_name(), self, person, checkbox))
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_working_task_str(), self, person, checkbox))
@@ -318,8 +322,9 @@ func _populate_personal_relation_data(person_list: Array, action):
 		_sorting_order.ASC:
 			_sorted_list = _sorting_list(person_list.duplicate())
 	for person in _sorted_list:
-		var checkbox = _checkbox(person.id)
+		var checkbox = null
 		if action != Action.LIST:
+			checkbox = _checkbox(person.id)
 			item_list.add_child(checkbox)
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_name(), self, person, checkbox))
 		item_list.add_child(_clickable_label_with_long_pressed_event(person.get_father_name(), self, person, checkbox))

--- a/UIMain/TabList/TabList.gd
+++ b/UIMain/TabList/TabList.gd
@@ -181,7 +181,8 @@ func _long_pressed_down_event(label):
 	
 func _long_pressed_up_event(label, receiver, object, checkbox):
 	if long_pressed_start_time > 0 and long_pressed_object_id > 0:
-		if OS.get_system_time_msecs() - long_pressed_start_time > LONG_PRESSED_TIME:
+		print(checkbox)
+		if OS.get_system_time_msecs() - long_pressed_start_time > LONG_PRESSED_TIME or checkbox == null:
 			emit_signal("long_pressed_signal", label, receiver, object, checkbox)
 		else:
 			emit_signal("single_pressed_signal", label, receiver, object, checkbox)

--- a/UIMain/TabList/TabList.gd
+++ b/UIMain/TabList/TabList.gd
@@ -181,7 +181,6 @@ func _long_pressed_down_event(label):
 	
 func _long_pressed_up_event(label, receiver, object, checkbox):
 	if long_pressed_start_time > 0 and long_pressed_object_id > 0:
-		print(checkbox)
 		if OS.get_system_time_msecs() - long_pressed_start_time > LONG_PRESSED_TIME or checkbox == null:
 			emit_signal("long_pressed_signal", label, receiver, object, checkbox)
 		else:


### PR DESCRIPTION
之前做功能的時候沒有考慮周全沒有單選框的情況：在人物詳情界面單擊不會直接出現人物資料，還是需要長按來觸發，現在修復了這個bug